### PR TITLE
Fix to use dark mode settings for barchatview label text.

### DIFF
--- a/Sources/SwiftUICharts/BarChart/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChart/BarChartView.swift
@@ -85,7 +85,9 @@ public struct BarChartView : View {
                         .padding()
                 }else if (self.data.valuesGiven && self.getCurrentValue() != nil) {
                     LabelView(arrowOffset: self.getArrowOffset(touchLocation: self.touchLocation),
-                              title: .constant(self.getCurrentValue()!.0)).offset(x: self.getLabelViewOffset(touchLocation: self.touchLocation), y: -6)
+                              title: .constant(self.getCurrentValue()!.0))
+                        .offset(x: self.getLabelViewOffset(touchLocation: self.touchLocation), y: -6)
+                        .foregroundColor(self.colorScheme == .dark ? self.darkModeStyle.legendTextColor : self.style.legendTextColor)
                 }
                 
             }


### PR DESCRIPTION
Label does not use dark mode settings, causing text to be invisible (tested on ios 13.4)