### PR TITLE
Resolves blank chart when choosing .large option.

### DIFF
--- a/Sources/SwiftUICharts/Helpers.swift
+++ b/Sources/SwiftUICharts/Helpers.swift
@@ -134,12 +134,12 @@ public struct ChartForm {
     #if os(watchOS)
     public static let small = CGSize(width:120, height:90)
     public static let medium = CGSize(width:120, height:160)
-    public static let large = CGSize(width:180, height:90)
+    public static let large = CGSize(width:180, height:160)
     public static let detail = CGSize(width:180, height:160)
     #else
     public static let small = CGSize(width:180, height:120)
     public static let medium = CGSize(width:180, height:240)
-    public static let large = CGSize(width:360, height:120)
+    public static let large = CGSize(width:360, height:240)
     public static let detail = CGSize(width:180, height:120)
     #endif
     


### PR DESCRIPTION
Was an issue with the lower height on the large option.