### PR TITLE
Making GradientColor's init method as public

### DIFF
--- a/Sources/SwiftUICharts/Helpers.swift
+++ b/Sources/SwiftUICharts/Helpers.swift
@@ -34,7 +34,7 @@ public struct GradientColor {
     public let start: Color
     public let end: Color
     
-    init(start: Color, end: Color) {
+    public init(start: Color, end: Color) {
         self.start = start
         self.end = end
     }


### PR DESCRIPTION
Making the method as public, application is allowed to define custom GradientColor.