### PR TITLE
adds option to set height

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ Available preset gradients:
 ![Line Charts](./Resources/fullscreen2.gif "Line Charts")
 
 ```swift
- LineView(data: [8,23,54,32,12,37,7,23,43], title: "Line chart", legend: "Full screen") // legend is optional, use optional .padding()
+LineView(data: [8,23,54,32,12,37,7,23,43], title: "Line chart", legend: "Full screen", height: 200)  
 ```
+
+`height`, `legend` and `title` are optional. `height` will default to 240 is not set. You may also use optional `.padding()`
 
 Adopts to dark mode automatically 
 

--- a/Sources/SwiftUICharts/LineChart/LineView.swift
+++ b/Sources/SwiftUICharts/LineChart/LineView.swift
@@ -123,7 +123,7 @@ public struct LineView: View {
 
 struct LineView_Previews: PreviewProvider {
     static var previews: some View {
-        LineView(data: [8,23,54,32,12,37,7,23,43], title: "Full chart", height: 1000, style: Styles.lineChartStyleOne).previewLayout(.fixed(width: 2000, height: 1000))
+        LineView(data: [8,23,54,32,12,37,7,23,43], title: "Full chart", height: 1000, style: Styles.lineChartStyleOne).padding(.top, -10).previewLayout(.fixed(width: 2000, height: 1000))
     }
 }
 

--- a/Sources/SwiftUICharts/LineChart/LineView.swift
+++ b/Sources/SwiftUICharts/LineChart/LineView.swift
@@ -12,6 +12,7 @@ public struct LineView: View {
     @ObservedObject var data: ChartData
     public var title: String?
     public var legend: String?
+    public var height: CGFloat?
     public var style: ChartStyle
     public var darkModeStyle: ChartStyle
     public var valueSpecifier:String
@@ -28,12 +29,14 @@ public struct LineView: View {
     public init(data: [Double],
                 title: String? = nil,
                 legend: String? = nil,
+                height: CGFloat? = nil,
                 style: ChartStyle = Styles.lineChartStyleOne,
                 valueSpecifier: String? = "%.1f") {
         
         self.data = ChartData(points: data)
         self.title = title
         self.legend = legend
+        self.height = height
         self.style = style
         self.valueSpecifier = valueSpecifier!
         self.darkModeStyle = style.darkModeStyle != nil ? style.darkModeStyle! : Styles.lineViewDarkMode
@@ -80,19 +83,19 @@ public struct LineView: View {
                             self.showLegend = false
                         }
                     }
-                    .frame(width: geometry.frame(in: .local).size.width, height: 240)
+                    .frame(width: geometry.frame(in: .local).size.width, height: self.height)
                     .offset(x: 0, y: 40 )
                     MagnifierRect(currentNumber: self.$currentDataNumber, valueSpecifier: self.valueSpecifier)
                         .opacity(self.opacity)
                         .offset(x: self.dragLocation.x - geometry.frame(in: .local).size.width/2, y: 36)
                 }
-                .frame(width: geometry.frame(in: .local).size.width, height: 240)
+                .frame(width: geometry.frame(in: .local).size.width, height: self.height ?? 240)
                 .gesture(DragGesture()
                 .onChanged({ value in
                     self.dragLocation = value.location
                     self.indicatorLocation = CGPoint(x: max(value.location.x-30,0), y: 32)
                     self.opacity = 1
-                    self.closestPoint = self.getClosestDataPoint(toPoint: value.location, width: geometry.frame(in: .local).size.width-30, height: 240)
+                    self.closestPoint = self.getClosestDataPoint(toPoint: value.location, width: geometry.frame(in: .local).size.width-30, height: self.height ?? 240)
                     self.hideHorizontalLines = true
                 })
                     .onEnded({ value in
@@ -120,7 +123,7 @@ public struct LineView: View {
 
 struct LineView_Previews: PreviewProvider {
     static var previews: some View {
-        LineView(data: [8,23,54,32,12,37,7,23,43], title: "Full chart", style: Styles.lineChartStyleOne)
+        LineView(data: [8,23,54,32,12,37,7,23,43], title: "Full chart", height: 1000, style: Styles.lineChartStyleOne).previewLayout(.fixed(width: 2000, height: 1000))
     }
 }
 


### PR DESCRIPTION
For supporting devices with wide screens especially in landscape mode.

Currently, when used in landscape on a tablet, the chart looks so stretched out that the chart looks flat.

tested in the preview.

```swift
struct LineView_Previews: PreviewProvider {
    static var previews: some View {
        LineView(data: [8,23,54,32,12,37,7,23,43], title: "Full chart", height: 1000, style: Styles.lineChartStyleOne).previewLayout(.fixed(width: 2000, height: 1000))
    }
}
```