### PR TITLE
LineChart: fix ViewBuilder closure

### DIFF
--- a/Sources/SwiftUICharts/LineChart/MultiLineChartView.swift
+++ b/Sources/SwiftUICharts/LineChart/MultiLineChartView.swift
@@ -85,15 +85,13 @@ public struct MultiLineChartView: View {
                                 .font(.callout)
                                 .foregroundColor(self.colorScheme == .dark ? self.darkModeStyle.legendTextColor : self.style.legendTextColor)
                         }
-                        if let rateValue = rateValue {
-                            HStack {
-                                if (rateValue >= 0){
-                                    Image(systemName: "arrow.up")
-                                }else{
-                                    Image(systemName: "arrow.down")
-                                }
-                                Text("\(rateValue)%")
+                        HStack {
+                            if (rateValue ?? 0 >= 0){
+                                Image(systemName: "arrow.up")
+                            }else{
+                                Image(systemName: "arrow.down")
                             }
+                            Text("\(rateValue ?? 0)%")
                         }
                     }
                     .transition(.opacity)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
ViewBuilder seems broken in Xcode 11.5, it seems to not accept condition closure anymore.
This is a (maybe temporary) fix to this issue, by using `??` (default value) instead.

## Motivation and Context
Issue #126 

## How Has This Been Tested?
I only did a build test and it worked.
As this is only replaced by default value, it should work as expected.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (Updating Documentation, CI automation, etc..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
