### PR TITLE
Dark/Light mode fixes

### DIFF
--- a/Sources/SwiftUICharts/Base/Label/ChartLabel.swift
+++ b/Sources/SwiftUICharts/Base/Label/ChartLabel.swift
@@ -49,13 +49,13 @@ public struct ChartLabel: View {
     private var labelColor: Color {
         switch labelType {
         case .title:
-            return .black
+            return Color(UIColor.label)
         case .legend:
-            return .gray
+            return Color(UIColor.secondaryLabel)
         case .subTitle:
-            return .black
+            return Color(UIColor.label)
         case .largeTitle:
-            return .black
+            return Color(UIColor.label)
         case .custom(_, _, let color):
             return color
         }

--- a/Sources/SwiftUICharts/Charts/LineChart/Line.swift
+++ b/Sources/SwiftUICharts/Charts/LineChart/Line.swift
@@ -94,7 +94,7 @@ extension Line {
             .fill(LinearGradient(gradient: Gradient(colors: [
                                                         style.foregroundColor.first?.startColor ?? .white,
                                                         style.foregroundColor.first?.endColor ?? .white,
-                                                        .white]),
+                                                        .clear]),
                                  startPoint: .bottom,
                                  endPoint: .top))
             .rotationEffect(.degrees(180), anchor: .center)


### PR DESCRIPTION
Fix for making ChartLabel text work with Dark/Light mode.

Also solves line chart background to appear white in dark mode (as shown below)
<img width="324" alt="Screen Shot 2020-07-30 at 11 17 36 PM" src="https://user-images.githubusercontent.com/15317925/88996315-e838ad80-d2ba-11ea-86e5-90234dcc37b5.png">
 
Will become 

<img width="319" alt="Screen Shot 2020-07-30 at 11 18 48 PM" src="https://user-images.githubusercontent.com/15317925/88996363-0bfbf380-d2bb-11ea-9250-f15b08ca5160.png">
