### PR TITLE
Add custom string format for ChartLabel when interactionInProgress = true

### DIFF
--- a/Sources/SwiftUICharts/Base/Label/ChartLabel.swift
+++ b/Sources/SwiftUICharts/Base/Label/ChartLabel.swift
@@ -11,6 +11,7 @@ public enum ChartLabelType {
 public struct ChartLabel: View {
     @EnvironmentObject var chartValue: ChartValue
     @State var textToDisplay:String = ""
+    var format: String = "%.01f"
 
     private var title: String
 
@@ -62,9 +63,11 @@ public struct ChartLabel: View {
     }
 
     public init (_ title: String,
-                 type: ChartLabelType = .title) {
+                 type: ChartLabelType = .title,
+                 format: String = "%.01f") {
         self.title = title
         labelType = type
+        self.format = format
     }
 
     public var body: some View {
@@ -78,7 +81,7 @@ public struct ChartLabel: View {
                     self.textToDisplay = self.title
                 }
                 .onReceive(self.chartValue.objectWillChange) { _ in
-                    self.textToDisplay = self.chartValue.interactionInProgress ? String(format: "%.01f", self.chartValue.currentValue) : self.title
+                    self.textToDisplay = self.chartValue.interactionInProgress ? String(format: format, self.chartValue.currentValue) : self.title
                 }
             if !self.chartValue.interactionInProgress {
                 Spacer()

--- a/Sources/SwiftUICharts/Base/Label/ChartLabel.swift
+++ b/Sources/SwiftUICharts/Base/Label/ChartLabel.swift
@@ -49,13 +49,13 @@ public struct ChartLabel: View {
     private var labelColor: Color {
         switch labelType {
         case .title:
-            return .black
+            return Color(UIColor.label)
         case .legend:
-            return .gray
+            return Color(UIColor.secondaryLabel)
         case .subTitle:
-            return .black
+            return Color(UIColor.label)
         case .largeTitle:
-            return .black
+            return Color(UIColor.label)
         case .custom(_, _, let color):
             return color
         }

--- a/Sources/SwiftUICharts/Charts/LineChart/Line.swift
+++ b/Sources/SwiftUICharts/Charts/LineChart/Line.swift
@@ -94,7 +94,7 @@ extension Line {
             .fill(LinearGradient(gradient: Gradient(colors: [
                                                         style.foregroundColor.first?.startColor ?? .white,
                                                         style.foregroundColor.first?.endColor ?? .white,
-                                                        .white]),
+                                                        .clear]),
                                  startPoint: .bottom,
                                  endPoint: .top))
             .rotationEffect(.degrees(180), anchor: .center)


### PR DESCRIPTION

## Description
This simply adds a new `format` string property for the `ChartLabel` struct. This is a feature in v1, so I thought it was worth bringing it in to v2 as I was playing around. It defaults to `"%.01f"` if none is provided.

Let me know if anything needs to change. This is my first ever contribution to Open Source. 👶

## Motivation and Context
This means I am able to supply my own custom format when I am interacting with my graph (with units shown too).

## How Has This Been Tested?
Tested in simulator on iOS 14. Default behaviour is the same as before (when no format is given).

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-04 at 16 34 45](https://user-images.githubusercontent.com/11502253/89313452-69ec5a80-d670-11ea-8f77-eaad8711bd6c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (Updating Documentation, CI automation, etc..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
