### PR TITLE
add support showing label for xAxis in LineChart

### DIFF
--- a/Sources/SwiftUICharts/LineChart/LineView.swift
+++ b/Sources/SwiftUICharts/LineChart/LineView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 public struct LineView: View {
     @ObservedObject var data: ChartData
+    public var xAxisData: [CustomStringConvertible]?
     public var title: String?
     public var legend: String?
     public var style: ChartStyle
@@ -24,14 +25,17 @@ public struct LineView: View {
     @State private var opacity:Double = 0
     @State private var currentDataNumber: Double = 0
     @State private var hideHorizontalLines: Bool = false
+    @State private var currentXValue: CustomStringConvertible?
     
     public init(data: [Double],
+                xAxisData: [CustomStringConvertible]? = nil,
                 title: String? = nil,
                 legend: String? = nil,
                 style: ChartStyle = Styles.lineChartStyleOne,
                 valueSpecifier: String? = "%.1f") {
         
         self.data = ChartData(points: data)
+        self.xAxisData = xAxisData
         self.title = title
         self.legend = legend
         self.style = style
@@ -83,7 +87,7 @@ public struct LineView: View {
                     }
                     .frame(width: geometry.frame(in: .local).size.width, height: 240)
                     .offset(x: 0, y: 40 )
-                    MagnifierRect(currentNumber: self.$currentDataNumber, valueSpecifier: self.valueSpecifier)
+                    MagnifierRect(currentNumber: self.$currentDataNumber, currentXValue: self.$currentXValue, valueSpecifier: self.valueSpecifier)
                         .opacity(self.opacity)
                         .offset(x: self.dragLocation.x - geometry.frame(in: .local).size.width/2, y: 36)
                 }
@@ -113,6 +117,11 @@ public struct LineView: View {
         let index:Int = Int(floor((toPoint.x-15)/stepWidth))
         if (index >= 0 && index < points.count){
             self.currentDataNumber = points[index]
+            if let xAxisData = xAxisData,
+               (index >= 0 && index < xAxisData.count)
+            {
+                self.currentXValue = xAxisData[index]
+            }
             return CGPoint(x: CGFloat(index)*stepWidth, y: CGFloat(points[index])*stepHeight)
         }
         return .zero

--- a/Sources/SwiftUICharts/LineChart/MagnifierRect.swift
+++ b/Sources/SwiftUICharts/LineChart/MagnifierRect.swift
@@ -9,25 +9,31 @@ import SwiftUI
 
 public struct MagnifierRect: View {
     @Binding var currentNumber: Double
+    @Binding var currentXValue: CustomStringConvertible?
     var valueSpecifier:String
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     public var body: some View {
-        ZStack{
+        VStack{
             Text("\(self.currentNumber, specifier: valueSpecifier)")
                 .font(.system(size: 18, weight: .bold))
-                .offset(x: 0, y:-110)
                 .foregroundColor(self.colorScheme == .dark ? Color.white : Color.black)
-            if (self.colorScheme == .dark ){
-                RoundedRectangle(cornerRadius: 16)
-                    .stroke(Color.white, lineWidth: self.colorScheme == .dark ? 2 : 0)
-                    .frame(width: 60, height: 260)
-            }else{
-                RoundedRectangle(cornerRadius: 16)
-                    .frame(width: 60, height: 280)
-                    .foregroundColor(Color.white)
-                    .shadow(color: Colors.LegendText, radius: 12, x: 0, y: 6 )
-                    .blendMode(.multiply)
+                .padding(16)
+            Spacer()
+            if let currentValue = currentXValue {
+                Text(String(describing: currentValue))
+                    .font(.system(size: 18, weight: .semibold, design: .default))
+                    .foregroundColor(self.colorScheme == .dark ? Color.white : Color.gray)
+                    .padding(16)
             }
         }
+        .background(colorScheme == .dark ?
+            AnyView(RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.white, lineWidth: self.colorScheme == .dark ? 2 : 0))
+            :
+            AnyView(RoundedRectangle(cornerRadius: 16)
+                .foregroundColor(Color.white)
+                .shadow(color: Colors.LegendText, radius: 12, x: 0, y: 6 )
+                .blendMode(.multiply))
+        )
     }
 }


### PR DESCRIPTION
## Description
Add ability to label xAxis in ChartView
```
LineView(
    data: [8,23,54,32,12,37,7,23,43],
    xAxisData: ["10-01-2013", "10-02-2013", "10-03-2013", "10-04-2013", "10-05-2013", "10-06-2013", "10-07-2013","10-08-2013","10-09-2013"], // New field
    title: "Line chart",
    legend: "Full screen"
)
```

## Motivation and Context
In LineChart the data may contain not only yAxis but may contain xAxis that represents, for example, date of data

## How Has This Been Tested?
Tested using examples project

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone 8 - 2020-10-20 at 19 08 12](https://user-images.githubusercontent.com/6975538/96583903-a0e51a80-1307-11eb-894c-cdcdc1769b2c.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (Updating Documentation, CI automation, etc..)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
