### PR TITLE
[WIP]Add an option to animate to back position (BarChart).

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,9 @@ You can access built-in styles:
 BarChartView(data: [8,23,54,32,12,37,7,23,43], title: "Title", form: ChartForm.small)
 ```
 
-### You can choose whether draggable label is back to origin or not by specifying `keepTouchLocation` (default is false).
-|keepTouchLocation is false|keepTouchLocation is true|
-|---|---|
-|![RPReplay_Final1603364812](https://user-images.githubusercontent.com/44002126/96867561-d6c10500-14a7-11eb-92ea-22cd57a4055f.gif)|![RPReplay_Final1603367132](https://user-images.githubusercontent.com/44002126/96867884-3c14f600-14a8-11eb-96c4-c918609e3fe8.gif)|
+### You can choose whether bar is animated or not after completing your gesture.
+
+If you want to animate back movement after completing your gesture, you set `animatedToBack` as `true`. 
 
 ### WatchOS support for Bar charts: 
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ You can access built-in styles:
 BarChartView(data: [8,23,54,32,12,37,7,23,43], title: "Title", form: ChartForm.small)
 ```
 
+### You can choose whether draggable label is back to origin or not by specifying `keepTouchLocation` (default is false).
+|keepTouchLocation is false|keepTouchLocation is true|
+|---|---|
+|![RPReplay_Final1603364812](https://user-images.githubusercontent.com/44002126/96867561-d6c10500-14a7-11eb-92ea-22cd57a4055f.gif)|![RPReplay_Final1603367132](https://user-images.githubusercontent.com/44002126/96867884-3c14f600-14a8-11eb-96c4-c918609e3fe8.gif)|
+
 ### WatchOS support for Bar charts: 
 
 ![Pie Charts](./Resources/watchos1.png "Pie Charts")

--- a/Sources/SwiftUICharts/BarChart/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChart/BarChartView.swift
@@ -107,9 +107,9 @@ public struct BarChartView : View {
                     }
                 })
                 .onEnded({ value in
-                    self.showValue = false
-                    self.showLabelValue = false
                     if !keepTouchLocation {
+                        self.showValue = false
+                        self.showLabelValue = false
                         self.touchLocation = -1
                     }
                 })

--- a/Sources/SwiftUICharts/BarChart/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChart/BarChartView.swift
@@ -111,6 +111,12 @@ public struct BarChartView : View {
                         self.showValue = false
                         self.showLabelValue = false
                         self.touchLocation = -1
+                    } else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            self.showValue = false
+                            self.showLabelValue = false
+                            self.touchLocation = -1
+                        }
                     }
                 })
         )

--- a/Sources/SwiftUICharts/BarChart/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChart/BarChartView.swift
@@ -19,7 +19,7 @@ public struct BarChartView : View {
     public var dropShadow: Bool
     public var cornerImage: Image
     public var valueSpecifier:String
-    public var keepTouchLocation: Bool
+    public var animatedToBack: Bool
     
     @State private var touchLocation: CGFloat = -1.0
     @State private var showValue: Bool = false
@@ -34,7 +34,7 @@ public struct BarChartView : View {
     var isFullWidth:Bool {
         return self.formSize == ChartForm.large
     }
-    public init(data:ChartData, title: String, legend: String? = nil, style: ChartStyle = Styles.barChartStyleOrangeLight, form: CGSize? = ChartForm.medium, dropShadow: Bool? = true, cornerImage:Image? = Image(systemName: "waveform.path.ecg"), valueSpecifier: String? = "%.1f", keepTouchLocation: Bool = false){
+    public init(data:ChartData, title: String, legend: String? = nil, style: ChartStyle = Styles.barChartStyleOrangeLight, form: CGSize? = ChartForm.medium, dropShadow: Bool? = true, cornerImage:Image? = Image(systemName: "waveform.path.ecg"), valueSpecifier: String? = "%.1f", animatedToBack: Bool = false){
         self.data = data
         self.title = title
         self.legend = legend
@@ -44,7 +44,7 @@ public struct BarChartView : View {
         self.dropShadow = dropShadow!
         self.cornerImage = cornerImage!
         self.valueSpecifier = valueSpecifier!
-        self.keepTouchLocation = keepTouchLocation
+        self.animatedToBack = animatedToBack
     }
     
     public var body: some View {
@@ -107,16 +107,18 @@ public struct BarChartView : View {
                     }
                 })
                 .onEnded({ value in
-                    if !keepTouchLocation {
+                    if animatedToBack {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            withAnimation(Animation.easeOut(duration: 1)) {
+                                self.showValue = false
+                                self.showLabelValue = false
+                                self.touchLocation = -1
+                            }
+                        }
+                    } else {
                         self.showValue = false
                         self.showLabelValue = false
                         self.touchLocation = -1
-                    } else {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                            self.showValue = false
-                            self.showLabelValue = false
-                            self.touchLocation = -1
-                        }
                     }
                 })
         )

--- a/Sources/SwiftUICharts/BarChart/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChart/BarChartView.swift
@@ -19,6 +19,7 @@ public struct BarChartView : View {
     public var dropShadow: Bool
     public var cornerImage: Image
     public var valueSpecifier:String
+    public var keepTouchLocation: Bool
     
     @State private var touchLocation: CGFloat = -1.0
     @State private var showValue: Bool = false
@@ -33,7 +34,7 @@ public struct BarChartView : View {
     var isFullWidth:Bool {
         return self.formSize == ChartForm.large
     }
-    public init(data:ChartData, title: String, legend: String? = nil, style: ChartStyle = Styles.barChartStyleOrangeLight, form: CGSize? = ChartForm.medium, dropShadow: Bool? = true, cornerImage:Image? = Image(systemName: "waveform.path.ecg"), valueSpecifier: String? = "%.1f"){
+    public init(data:ChartData, title: String, legend: String? = nil, style: ChartStyle = Styles.barChartStyleOrangeLight, form: CGSize? = ChartForm.medium, dropShadow: Bool? = true, cornerImage:Image? = Image(systemName: "waveform.path.ecg"), valueSpecifier: String? = "%.1f", keepTouchLocation: Bool = false){
         self.data = data
         self.title = title
         self.legend = legend
@@ -43,6 +44,7 @@ public struct BarChartView : View {
         self.dropShadow = dropShadow!
         self.cornerImage = cornerImage!
         self.valueSpecifier = valueSpecifier!
+        self.keepTouchLocation = keepTouchLocation
     }
     
     public var body: some View {
@@ -107,7 +109,9 @@ public struct BarChartView : View {
                 .onEnded({ value in
                     self.showValue = false
                     self.showLabelValue = false
-                    self.touchLocation = -1
+                    if !keepTouchLocation {
+                        self.touchLocation = -1
+                    }
                 })
         )
             .gesture(TapGesture()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I want to keep the label in its final state after the bottom label of the graph has been dragged.

## Description, Motivation and Context
<!--- Describe your changes in detail -->
Like the following GIF, we cannot keep `BarChartView#touchLocation` after dragging label.
![RPReplay_Final1603364812](https://user-images.githubusercontent.com/44002126/96867561-d6c10500-14a7-11eb-92ea-22cd57a4055f.gif)

It is not always a problem, but this featuer may not be flexible. I prefer to choose whether it keeps the `touchLocation` after dragging.

|My desired behavior|
|---|
|![RPReplay_Final1603367132](https://user-images.githubusercontent.com/44002126/96867884-3c14f600-14a8-11eb-96c4-c918609e3fe8.gif)|

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- ⌘ + U
- Run on real device in te following environment.
    - iOS 14
    - Xcode12.0.1
    - iPhone SE (2nd)

Please watch the result.
![RPReplay_Final1603367132](https://user-images.githubusercontent.com/44002126/96867884-3c14f600-14a8-11eb-96c4-c918609e3fe8.gif)


## Screenshots (if appropriate):
|before|after|
|---|---|
|![RPReplay_Final1603364812](https://user-images.githubusercontent.com/44002126/96867561-d6c10500-14a7-11eb-92ea-22cd57a4055f.gif)|![RPReplay_Final1603367132](https://user-images.githubusercontent.com/44002126/96867884-3c14f600-14a8-11eb-96c4-c918609e3fe8.gif)|

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (Updating Documentation, CI automation, etc..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
