### PR TITLE
Bugfix: Line height in LineView

### DIFF
--- a/Sources/SwiftUICharts/LineChart/LineView.swift
+++ b/Sources/SwiftUICharts/LineChart/LineView.swift
@@ -65,7 +65,7 @@ public struct LineView: View {
                                 .animation(Animation.easeOut(duration: 1).delay(1))
                         }
                         Line(data: self.data,
-                             frame: .constant(CGRect(x: 0, y: 0, width: reader.frame(in: .local).width - 30, height: reader.frame(in: .local).height)),
+                             frame: .constant(CGRect(x: 0, y: 0, width: reader.frame(in: .local).width - 30, height: reader.frame(in: .local).height + 25)),
                              touchLocation: self.$indicatorLocation,
                              showIndicator: self.$hideHorizontalLines,
                              minDataValue: .constant(nil),
@@ -73,7 +73,7 @@ public struct LineView: View {
                              showBackground: false,
                              gradient: self.style.gradientColor
                         )
-                        .offset(x: 30, y: -20)
+                        .offset(x: 30, y: 0)
                         .onAppear(){
                             self.showLegend = true
                         }

--- a/Sources/SwiftUICharts/LineChart/MagnifierRect.swift
+++ b/Sources/SwiftUICharts/LineChart/MagnifierRect.swift
@@ -29,6 +29,6 @@ public struct MagnifierRect: View {
                     .blendMode(.multiply)
             }
         }
-        .offset(x: 0, y: -25)
+        .offset(x: 0, y: -15)
     }
 }

--- a/Sources/SwiftUICharts/LineChart/MagnifierRect.swift
+++ b/Sources/SwiftUICharts/LineChart/MagnifierRect.swift
@@ -29,5 +29,6 @@ public struct MagnifierRect: View {
                     .blendMode(.multiply)
             }
         }
+        .offset(x: 0, y: -25)
     }
 }


### PR DESCRIPTION
Fixes an issue in the LineView where the line wasn't sitting at the lowest data point and not reaching the highest data point.

## Description
In LineView make the Line frame height larger.
Set Lines y offset to 0

## Motivation and Context
Fix #132 

## How Has This Been Tested?
iPhone SE simulator
iPhone 12 Max simulator
iPhone 11 Device

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone 12 Pro Max - 2020-11-19 at 10 25 34](https://user-images.githubusercontent.com/63838770/99654072-bdcd5480-2a51-11eb-8929-0093db88e9ee.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (Updating Documentation, CI automation, etc..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. --I think it does.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
