### PR TITLE
macOS support: v11 only. Swift tools bumped to 5.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.build
 /Packages
 /*.xcodeproj
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftUICharts",
     platforms: [
-        .iOS(.v13), .watchOS(.v6), .macOS(.v10_15)
+        .iOS(.v13), .watchOS(.v6), .macOS(.v11)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Sources/SwiftUICharts/Helpers.swift
+++ b/Sources/SwiftUICharts/Helpers.swift
@@ -268,11 +268,15 @@ class HapticFeedback {
     static func playSelection() -> Void {
         WKInterfaceDevice.current().play(.click)
     }
-    #else
+    #elseif os(iOS)
     //iOS implementation
     let selectionFeedbackGenerator = UISelectionFeedbackGenerator()
     static func playSelection() -> Void {
         UISelectionFeedbackGenerator().selectionChanged()
+    }
+    #else
+    static func playSelection() -> Void {
+        //No-op
     }
     #endif
 }


### PR DESCRIPTION
Minor edits to allow macOS support

## Description
Added support for macOS by bumping version to .v11
v11 support required Swift tools 5.3

## How Has This Been Tested?
Basic test charts run in macOS

