### PR TITLE
Fixing line chart view dynamic height

### DIFF
--- a/Sources/SwiftUICharts/LineChart/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChart/LineChartView.swift
@@ -58,7 +58,7 @@ public struct LineChartView: View {
         ZStack(alignment: .center){
             RoundedRectangle(cornerRadius: 20)
                 .fill(self.colorScheme == .dark ? self.darkModeStyle.backgroundColor : self.style.backgroundColor)
-                .frame(width: frame.width, height: 240, alignment: .center)
+                .frame(width: frame.width, height: frame.height, alignment: .center)
                 .shadow(color: self.style.dropShadowColor, radius: self.dropShadow ? 8 : 0)
             VStack(alignment: .leading){
                 if(!self.showIndicatorDot){


### PR DESCRIPTION
Fix line chart fixed height

## Description
line charts were fixed height instead of following the `formSize`

## Motivation and Context
Trying to use line charts in a personal project but the frame doesn't fit

## How Has This Been Tested?
Instantiate a line chart and change its formSize

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone 12 - 2021-05-17 at 10 34 36](https://user-images.githubusercontent.com/43816241/118499062-f9916000-b6fc-11eb-83f5-b9fdb4e5116d.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (Updating Documentation, CI automation, etc..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
