### PR TITLE
Fixed console warning message "ignoring singular matrix" when dealing with PieChart

### DIFF
--- a/Sources/SwiftUICharts/Charts/PieChart/PieChartCell.swift
+++ b/Sources/SwiftUICharts/Charts/PieChart/PieChartCell.swift
@@ -47,7 +47,7 @@ public struct PieChartCell: View {
             path
                 .fill(self.accentColor.linearGradient(from: .bottom, to: .top))
                 .overlay(path.stroke(self.backgroundColor, lineWidth: (startDeg == 0 && endDeg == 0 ? 0 : 2)))
-                .scaleEffect(self.show ? 1 : 0)
+                .scaleEffect(self.show ? 1 : 0.01)
                 .animation(Animation.spring().delay(Double(self.index) * 0.04))
                 .onAppear {
                     self.show = true


### PR DESCRIPTION
Fixed console warning message "ignoring singular matrix: ProjectionTransform(m11: 5e-324, m12: 0.0, m13: 0.0, m21: 0.0, m22: 5e-324, m23: 0.0, m31: 100.0, m32: 100.0, m33: 1.0)" when dealing with PieChart by modifying scale effect

## Description
When dealing with PieChart, we have this warning message in console "ignoring singular matrix". This is an issue when dealing with ScaleEffect modifier.
[https://stackoverflow.com/questions/63630107/swiftui-unknown-process-name-cgaffinetransforminvert-singular-matrix-error](url)

## Motivation and Context
This is just a simple modification to avoid useless warning spamming messages on the console

## How Has This Been Tested?
- A fork was made from ChartView.
- The fixed was made on the branch `new-version-beta2`
- Added this fork on a SwiftUI project that has the issue with Swift Package Manager
- No more warning messages and PieChart works like before

Testing on Xcode 12.4 / Project build on iOS 14.1

## Screenshots (if appropriate):
Screenshot of the issue:
<img width="619" alt="Screen Shot 2021-09-19 at 10 57 27 AM" src="https://user-images.githubusercontent.com/841028/133932255-7003131f-20e8-426d-9ae7-3a64453d3c71.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (Updating Documentation, CI automation, etc..)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
