### PR TITLE
Fixes crash which sometimes happens in PieChartRow

### DIFF
--- a/Sources/SwiftUICharts/LineChart/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChart/LineChartView.swift
@@ -76,12 +76,12 @@ public struct LineChartView: View {
                             
                             if let rateValue = self.rateValue
                             {
-                                if (rateValue ?? 0 >= 0){
+                                if (rateValue >= 0) {
                                     Image(systemName: "arrow.up")
                                 }else{
                                     Image(systemName: "arrow.down")
                                 }
-                                Text("\(rateValue!)%")
+                                Text("\(rateValue)%")
                             }
                         }
                     }
@@ -142,10 +142,10 @@ public struct LineChartView: View {
 struct WidgetView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            LineChartView(data: [8,23,54,32,12,37,7,23,43], title: "Line chart", legend: "Basic")
+            LineChartView(data: [8,23,54,32,12,37,7,23,43], title: "Line chart", legend: "Basic", rateValue: (43-8)*100/8)
                 .environment(\.colorScheme, .light)
             
-            LineChartView(data: [282.502, 284.495, 283.51, 285.019, 285.197, 286.118, 288.737, 288.455, 289.391, 287.691, 285.878, 286.46, 286.252, 284.652, 284.129, 284.188], title: "Line chart", legend: "Basic")
+            LineChartView(data: [282.502, 284.495, 283.51, 285.019, 285.197, 286.118, 288.737, 288.455, 289.391, 287.691, 285.878, 286.46, 286.252, 284.652, 284.129, 284.188], title: "Line chart", legend: "Basic", rateValue: Int((284.188-282.502)*100.0/282.502))
             .environment(\.colorScheme, .light)
         }
     }

--- a/Sources/SwiftUICharts/PieChart/PieChartRow.swift
+++ b/Sources/SwiftUICharts/PieChart/PieChartRow.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 public struct PieChartRow : View {
+    
     var data: [Double]
     var backgroundColor: Color
     var accentColor: Color
@@ -38,11 +39,17 @@ public struct PieChartRow : View {
         }
     }
     
+    private func getSlice(index: Int) -> PieSlice? {
+        return slices.count >= index ? slices[index] : nil
+    }
+    
     public var body: some View {
         GeometryReader { geometry in
+            let slicesSnapshot = self.slices
             ZStack{
-                ForEach(0..<self.slices.count){ i in
-                    PieChartCell(rect: geometry.frame(in: .local), startDeg: self.slices[i].startDeg, endDeg: self.slices[i].endDeg, index: i, backgroundColor: self.backgroundColor,accentColor: self.accentColor)
+                
+                ForEach(0..<slicesSnapshot.count){ i in
+                    PieChartCell(rect: geometry.frame(in: .local), startDeg: slicesSnapshot[i].startDeg, endDeg: slicesSnapshot[i].endDeg, index: i, backgroundColor: self.backgroundColor,accentColor: self.accentColor)
                         .scaleEffect(self.currentTouchedIndex == i ? 1.1 : 1)
                         .animation(Animation.spring())
                 }
@@ -53,7 +60,7 @@ public struct PieChartRow : View {
                             let isTouchInPie = isPointInCircle(point: value.location, circleRect: rect)
                             if isTouchInPie {
                                 let touchDegree = degree(for: value.location, inCircleRect: rect)
-                                self.currentTouchedIndex = self.slices.firstIndex(where: { $0.startDeg < touchDegree && $0.endDeg > touchDegree }) ?? -1
+                                self.currentTouchedIndex = slicesSnapshot.firstIndex(where: { $0.startDeg < touchDegree && $0.endDeg > touchDegree }) ?? -1
                             } else {
                                 self.currentTouchedIndex = -1
                             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We experience random crashes sometimes when the PieChartRow data is mutated often (see below screenshot).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- This code makes the race condition that was causing the crash not possible. 
- It also fixes the compile error i'm getting on Xcode 15

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Crash when the slices index was out of range because the data was mutated whilst getting it.
<img width="675" alt="Screenshot 2023-09-29 at 11 31 04" src="https://github.com/AppPear/ChartView/assets/2333536/f7a12f27-7995-47b1-97bc-204c0e49cacc">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (Updating Documentation, CI automation, etc..)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
