### PR TITLE
Implement a simulation example of dice rolls

### DIFF
--- a/Examples/DiceRollSimulation/DiceRollSimulation.xcodeproj/project.pbxproj
+++ b/Examples/DiceRollSimulation/DiceRollSimulation.xcodeproj/project.pbxproj
@@ -1,0 +1,365 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0D60101C2FA017F000039A0E /* SwiftUICharts in Frameworks */ = {isa = PBXBuildFile; productRef = 0D60101B2FA017F000039A0E /* SwiftUICharts */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0D60100C2FA017E300039A0E /* DiceRollSimulation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DiceRollSimulation.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		0D60100E2FA017E300039A0E /* DiceRollSimulation */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = DiceRollSimulation;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0D6010092FA017E300039A0E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0D60101C2FA017F000039A0E /* SwiftUICharts in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0D6010032FA017E300039A0E = {
+			isa = PBXGroup;
+			children = (
+				0D60100E2FA017E300039A0E /* DiceRollSimulation */,
+				0D60100D2FA017E300039A0E /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		0D60100D2FA017E300039A0E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0D60100C2FA017E300039A0E /* DiceRollSimulation.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0D60100B2FA017E300039A0E /* DiceRollSimulation */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0D6010172FA017E400039A0E /* Build configuration list for PBXNativeTarget "DiceRollSimulation" */;
+			buildPhases = (
+				0D6010082FA017E300039A0E /* Sources */,
+				0D6010092FA017E300039A0E /* Frameworks */,
+				0D60100A2FA017E300039A0E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				0D60100E2FA017E300039A0E /* DiceRollSimulation */,
+			);
+			name = DiceRollSimulation;
+			packageProductDependencies = (
+				0D60101B2FA017F000039A0E /* SwiftUICharts */,
+			);
+			productName = DiceRollSimulation;
+			productReference = 0D60100C2FA017E300039A0E /* DiceRollSimulation.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0D6010042FA017E300039A0E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2620;
+				LastUpgradeCheck = 2620;
+				TargetAttributes = {
+					0D60100B2FA017E300039A0E = {
+						CreatedOnToolsVersion = 26.2;
+					};
+				};
+			};
+			buildConfigurationList = 0D6010072FA017E300039A0E /* Build configuration list for PBXProject "DiceRollSimulation" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0D6010032FA017E300039A0E;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				0D60101A2FA017F000039A0E /* XCRemoteSwiftPackageReference "ChartView" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 0D60100D2FA017E300039A0E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0D60100B2FA017E300039A0E /* DiceRollSimulation */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0D60100A2FA017E300039A0E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0D6010082FA017E300039A0E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0D6010152FA017E400039A0E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 56M82254ZM;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		0D6010162FA017E400039A0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 56M82254ZM;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		0D6010182FA017E400039A0E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 56M82254ZM;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mohammedalwosaibi.DiceRollSimulation;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0D6010192FA017E400039A0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 56M82254ZM;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mohammedalwosaibi.DiceRollSimulation;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0D6010072FA017E300039A0E /* Build configuration list for PBXProject "DiceRollSimulation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0D6010152FA017E400039A0E /* Debug */,
+				0D6010162FA017E400039A0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0D6010172FA017E400039A0E /* Build configuration list for PBXNativeTarget "DiceRollSimulation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0D6010182FA017E400039A0E /* Debug */,
+				0D6010192FA017E400039A0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		0D60101A2FA017F000039A0E /* XCRemoteSwiftPackageReference "ChartView" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/AppPear/ChartView";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		0D60101B2FA017F000039A0E /* SwiftUICharts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0D60101A2FA017F000039A0E /* XCRemoteSwiftPackageReference "ChartView" */;
+			productName = SwiftUICharts;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 0D6010042FA017E300039A0E /* Project object */;
+}

--- a/Examples/DiceRollSimulation/DiceRollSimulation.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/DiceRollSimulation/DiceRollSimulation.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/DiceRollSimulation/DiceRollSimulation.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/DiceRollSimulation/DiceRollSimulation.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "4fa034e453faafc0169cb98ce1b88bc4e38f64f1cc0a176127db6dd00618e302",
+  "pins" : [
+    {
+      "identity" : "chartview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AppPear/ChartView",
+      "state" : {
+        "revision" : "2a1572430eacc31311a9b23d7dfa1e9cf9e49234",
+        "version" : "2.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Examples/DiceRollSimulation/DiceRollSimulation.xcodeproj/xcuserdata/mohammedalwosaibi.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Examples/DiceRollSimulation/DiceRollSimulation.xcodeproj/xcuserdata/mohammedalwosaibi.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>DiceRollSimulation.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Examples/DiceRollSimulation/DiceRollSimulation/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/DiceRollSimulation/DiceRollSimulation/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/DiceRollSimulation/DiceRollSimulation/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/DiceRollSimulation/DiceRollSimulation/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/DiceRollSimulation/DiceRollSimulation/Assets.xcassets/Contents.json
+++ b/Examples/DiceRollSimulation/DiceRollSimulation/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/DiceRollSimulation/DiceRollSimulation/ContentView.swift
+++ b/Examples/DiceRollSimulation/DiceRollSimulation/ContentView.swift
@@ -1,0 +1,221 @@
+import SwiftUI
+import SwiftUICharts
+
+struct ContentView: View {
+    @State private var diceData: [Double] = Array(repeating: 0, count: 11)
+    @State private var totalRolls: Int = 0
+    @State private var totalSum: Int = 0
+    @State private var rollsPerSecond: Double = 1.0
+    @State private var die1Value: Int = 1
+    @State private var die2Value: Int = 1
+
+    var currentMean: Double {
+        totalRolls == 0 ? 0.0 : Double(totalSum) / Double(totalRolls)
+    }
+    
+    var yAxisLabels: [String] {
+        let maxVal = diceData.max() ?? 0
+        guard maxVal > 0 else { return ["0", "", "", "", ""] }
+        let step = (maxVal / 4).rounded(.up)
+        return (0...4).map { "\(Int(Double($0) * step))" }
+    }
+
+    var meanColor: Color {
+        totalRolls > 0 && abs(currentMean - 7.0) < 0.1 ? .green : .primary
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                header
+                diceRow
+                statsRow
+                chartCard
+                speedCard
+                resetButton
+            }
+            .padding()
+        }
+        .background(
+            LinearGradient(
+                colors: [Color(.systemGroupedBackground), Color(.systemBackground)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+        )
+        .task(id: rollsPerSecond) {
+            while !Task.isCancelled {
+                let interval = (1.0 / rollsPerSecond) * 1_000_000_000
+                try? await Task.sleep(nanoseconds: UInt64(interval))
+                rollDice()
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 4) {
+            Text("Law of Large Numbers")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var diceRow: some View {
+        HStack(spacing: 24) {
+            DieView(value: die1Value)
+            DieView(value: die2Value)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var statsRow: some View {
+        HStack(spacing: 12) {
+            StatCard(title: "MEAN",
+                     value: String(format: "%.3f", currentMean),
+                     color: meanColor)
+            StatCard(title: "ROLLS",
+                     value: "\(totalRolls)",
+                     color: .blue)
+            StatCard(title: "LAST SUM",
+                     value: "\(die1Value + die2Value)",
+                     color: .purple)
+        }
+    }
+
+    private var chartCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Distribution of Sums")
+                    .font(.headline)
+                Spacer()
+                Text("Roll count per outcome")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            AxisLabels {
+                ChartGrid {
+                    BarChart()
+                        .chartData(diceData)
+                        .chartStyle(
+                            ChartStyle(
+                                backgroundColor: Color(.secondarySystemBackground),
+                                foregroundColor: ColorGradient(.orange, .red)
+                            )
+                        )
+                }
+                .chartGridLines(horizontal: 5, vertical: 11)
+            }
+            .chartXAxisLabels(["2","3","4","5","6","7","8","9","10","11","12"])
+            .chartYAxisLabels(yAxisLabels)
+            .chartAxisColor(.secondary)
+            .chartAxisFont(.caption2)
+            .frame(height: 240)
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+
+    private var speedCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label("Speed", systemImage: "speedometer")
+                    .font(.headline)
+                Spacer()
+                Text("\(String(format: "%.1f", rollsPerSecond)) /sec")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Slider(value: $rollsPerSecond, in: 0.5...10.0, step: 0.5)
+                .tint(.blue)
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+
+    private var resetButton: some View {
+        Button {
+            withAnimation {
+                diceData = Array(repeating: 0, count: 11)
+                totalRolls = 0
+                totalSum = 0
+                die1Value = 1
+                die2Value = 1
+            }
+        } label: {
+            Label("Reset", systemImage: "arrow.counterclockwise")
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 4)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(.red)
+        .controlSize(.large)
+    }
+
+    func rollDice() {
+        let d1 = Int.random(in: 1...6)
+        let d2 = Int.random(in: 1...6)
+        let sum = d1 + d2
+
+        die1Value = d1
+        die2Value = d2
+        diceData[sum - 2] += 1
+        totalRolls += 1
+        totalSum += sum
+    }
+}
+
+struct DieView: View {
+    let value: Int
+
+    var body: some View {
+        Image(systemName: "die.face.\(value).fill")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 80, height: 80)
+            .foregroundStyle(.blue.gradient)
+            .shadow(color: .blue.opacity(0.25), radius: 8, x: 0, y: 4)
+            .contentTransition(.symbolEffect(.replace))
+    }
+}
+
+struct StatCard: View {
+    let title: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .tracking(0.5)
+            Text(value)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundStyle(color)
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Examples/DiceRollSimulation/DiceRollSimulation/DiceRollSimulationApp.swift
+++ b/Examples/DiceRollSimulation/DiceRollSimulation/DiceRollSimulationApp.swift
@@ -1,0 +1,17 @@
+//
+//  DiceRollSimulationApp.swift
+//  DiceRollSimulation
+//
+//  Created by Mohammed Alwosaibi on 4/27/26.
+//
+
+import SwiftUI
+
+@main
+struct DiceRollSimulationApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
**Title:** Docs: Add Dice Roll Probability Simulation Example

## Description
Added a new SwiftUI example project demonstrating how to use `BarChart()` to visualize dynamically updating categorical data. The example simulates rolling two dice, calculating their sums (2-12), and continuously updating the bar chart to visualize the Law of Large Numbers as the mean converges to 7. 

## Motivation and Context
This provides a fun, highly visual example for new users learning the v2.0.0 framework. It specifically demonstrates how to bind a dynamically changing `[Double]` array to the `.chartData()` modifier inside a continuous asynchronous `Task`, proving the chart updates efficiently in real-time.

## How Has This Been Tested?
Built and run locally on the iOS Simulator via Xcode. Tested the slider to alter the frequency of data updates (from 0.5 to 10 updates per second) to ensure the `BarChart` view redraws smoothly without performance drops or crashes.

## Screenshots (if appropriate):
*(Drag and drop a quick screenshot or screen recording of your app running here)*

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Non-functional change (Updating Documentation, CI automation, etc..)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.